### PR TITLE
[D2] Icon 구현 및 Preview 작성

### DIFF
--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/Image+Icon.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/Image+Icon.swift
@@ -1,0 +1,19 @@
+//
+//  Image+Icon.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/05/27.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public extension Image {
+    static func icon(_ type: any IconRepresentable) -> Image {
+        image(type.name)
+    }
+    
+    private static func image(_ name: String) -> Image {
+        .init(name, bundle: Bundle(identifier: DesignSystemKit.bundleId)!)
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/Image+Icon.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/Image+Icon.swift
@@ -9,11 +9,7 @@
 import SwiftUI
 
 public extension Image {
-    static func icon(_ type: any IconRepresentable) -> Image {
-        image(type.name)
-    }
-    
-    private static func image(_ name: String) -> Image {
-        .init(name, bundle: Bundle(identifier: DesignSystemKit.bundleId)!)
+    init(_ representable: any IconRepresentable) {
+        self = .init(representable.name, bundle: Bundle(identifier: DesignSystemKit.bundleId)!)
     }
 }

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Icon.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Icon.swift
@@ -8,15 +8,13 @@
 
 import Foundation
 
-public extension DesignSystemKit {
-    enum Icon {}
-}
+public enum Icon {}
 
 public protocol IconRepresentable: CaseIterable {
     var name: String { get }
 }
 
-public extension DesignSystemKit.Icon {
+public extension Icon {
     
     // MARK: - Chevron
     

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Icon.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Icon.swift
@@ -1,0 +1,152 @@
+//
+//  Icon.swift
+//  DesignSystemUI
+//
+//  Created by AhnSangHoon on 2023/05/29.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import Foundation
+
+public extension DesignSystemKit {
+    enum Icon {}
+}
+
+public protocol IconRepresentable: CaseIterable {
+    var name: String { get }
+}
+
+public extension DesignSystemKit.Icon {
+    
+    // MARK: - Chevron
+    
+    enum Chevron: IconRepresentable {
+        case upBig
+        case upMedium
+        case upSmall
+        case downBig
+        case downMedium
+        case downSmall
+        case leftBig
+        case leftMedium
+        case leftSmall
+        case rightBig
+        case rightMedium
+        case rightSmall
+        
+        public var name: String {
+            switch self {
+                case .upBig: return "chevron_up_big"
+                case .upMedium: return "chevron_up_medium"
+                case .upSmall: return "chevron_up_small"
+                case .downBig: return "chevron_down_big"
+                case .downMedium: return "chevron_down_medium"
+                case .downSmall: return "chevron_down_small"
+                case .leftBig: return "chevron_left_big"
+                case .leftMedium: return "chevron_left_medium"
+                case .leftSmall: return "chevron_left_small"
+                case .rightBig: return "chevron_right_big"
+                case .rightMedium: return "chevron_right_medium"
+                case .rightSmall: return "chevron_right_small"
+            }
+        }
+    }
+    
+    // MARK: - Checkmark
+    
+    enum Checkmark: IconRepresentable {
+        case falseFill20
+        case falseFill24
+        case falseLine20
+        case falseLine24
+        case trueFill20
+        case trueFill24
+        
+        public var name: String {
+            switch self {
+            case .falseFill20: return "checkmark_false_fill_20"
+            case .falseFill24: return "checkmark_false_fill_24"
+            case .falseLine20: return "checkmark_false_line_20"
+            case .falseLine24: return "checkmark_false_line_24"
+            case .trueFill20: return "checkmark_true_fill_20"
+            case .trueFill24: return "checkmark_true_fill_24"
+            }
+        }
+    }
+    
+    // MARK: - CircleAlert
+    
+    enum CircleAlert: IconRepresentable {
+        case fillMono
+        
+        public var name: String {
+            switch self {
+            case .fillMono: return "circle_alert_fill_mono"
+            }
+        }
+    }
+    
+    // MARK: - Close
+    
+    enum Close: IconRepresentable {
+        case fillBlack
+        case fillGray
+        
+        public var name: String {
+            switch self {
+            case .fillBlack: return "close_fill_black"
+            case .fillGray: return "close_fill_gray"
+            }
+        }
+    }
+
+    // MARK: - Edit
+    
+    enum Edit: IconRepresentable {
+        case list
+        
+        public var name: String {
+            switch self {
+            case .list: return "edit_list"
+            }
+        }
+    }
+
+    // MARK: - Ranking
+    
+    enum Ranking: IconRepresentable {
+        case down
+        case up
+        
+        public var name: String {
+            switch self {
+            case .down: return "ranking_down"
+            case .up: return "ranking_up"
+            }
+        }
+    }
+
+    // MARK: - Siren
+    
+    enum Siren: IconRepresentable {
+        case mono
+        
+        public var name: String {
+            switch self {
+            case .mono: return "siren_mono"
+            }
+        }
+    }
+
+    // MARK: - Magnifier
+    
+    enum Magnifier: IconRepresentable {
+        case lineGray
+        
+        public var name: String {
+            switch self {
+            case .lineGray: return "maginfier_line_gray"
+            }
+        }
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ContentView.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ContentView.swift
@@ -7,15 +7,26 @@ public struct ContentView: View {
         /// Preview에서 Typography를 적용하려면 아래 코드를 작성해야합니다
         _ = try? DesignSystemKit.Pretendard.registerFonts()
     }
+    
+    private enum NavigationType: Hashable {
+        case typography(TypographyPreview.TypographyType)
+        case icon
+    }
 
     public var body: some View {
         NavigationStack {
             List {
-                NavigationLink("Typography Semantic", value: TypographyPreview.TypographyType.semantic)
-                NavigationLink("Typography Manual", value: TypographyPreview.TypographyType.manual)
+                NavigationLink("Typography Semantic", value: NavigationType.typography(.semantic))
+                NavigationLink("Typography Manual", value: NavigationType.typography(.manual))
+                NavigationLink("Icon", value: NavigationType.icon)
             }
-            .navigationDestination(for: TypographyPreview.TypographyType.self) {
-                TypographyPreview(typographyType: $0)
+            .navigationDestination(for: NavigationType.self) {
+                switch $0 {
+                case let .typography(type):
+                    TypographyPreview(typographyType: type)
+                case .icon:
+                    IconPreview()
+                }
             }
             .navigationTitle("WeQuiz DesignSystem")
         }

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/IconPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/IconPreview.swift
@@ -1,0 +1,154 @@
+//
+//  IconPreview.swift
+//  DesignSystemUI
+//
+//  Created by AhnSangHoon on 2023/05/29.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+import DesignSystemKit
+
+struct IconPreview: View {
+    typealias IconDataSet = (title: String, data: [any IconRepresentable])
+    
+    private let chevron: IconDataSet = (
+        "Chevron",
+        [
+           DesignSystemKit.Icon.Chevron.upBig,
+           DesignSystemKit.Icon.Chevron.upMedium,
+           DesignSystemKit.Icon.Chevron.upSmall,
+           DesignSystemKit.Icon.Chevron.downBig,
+           DesignSystemKit.Icon.Chevron.downMedium,
+           DesignSystemKit.Icon.Chevron.downSmall,
+           DesignSystemKit.Icon.Chevron.leftBig,
+           DesignSystemKit.Icon.Chevron.leftMedium,
+           DesignSystemKit.Icon.Chevron.leftSmall,
+           DesignSystemKit.Icon.Chevron.rightBig,
+           DesignSystemKit.Icon.Chevron.rightMedium,
+           DesignSystemKit.Icon.Chevron.rightSmall
+       ]
+    )
+    
+    private let checkmark: IconDataSet = (
+        "Checkmark",
+        [
+            DesignSystemKit.Icon.Checkmark.trueFill24,
+            DesignSystemKit.Icon.Checkmark.trueFill20,
+            DesignSystemKit.Icon.Checkmark.falseLine24,
+            DesignSystemKit.Icon.Checkmark.falseLine20,
+            DesignSystemKit.Icon.Checkmark.falseFill24,
+            DesignSystemKit.Icon.Checkmark.falseFill20
+        ]
+    )
+    
+    private let circleAlert: IconDataSet = (
+        "CircleAlert",
+        [
+            DesignSystemKit.Icon.CircleAlert.fillMono
+        ]
+    )
+    
+    private let close: IconDataSet = (
+        "Close",
+        [
+            DesignSystemKit.Icon.Close.fillBlack,
+            DesignSystemKit.Icon.Close.fillGray,
+        ]
+    )
+    
+    private let edit: IconDataSet = (
+        "Edit",
+        [
+            DesignSystemKit.Icon.Edit.list
+        ]
+    )
+    
+    private let ranking: IconDataSet = (
+        "Ranking",
+        [
+            DesignSystemKit.Icon.Ranking.down,
+            DesignSystemKit.Icon.Ranking.up,
+        ]
+    )
+    
+    private let siren: IconDataSet = (
+        "Siren",
+        [
+            DesignSystemKit.Icon.Siren.mono
+        ]
+    )
+    
+    private let magnifier: IconDataSet = (
+        "Magnifier",
+        [
+            DesignSystemKit.Icon.Magnifier.lineGray
+        ]
+    )
+    
+    private struct IconSectionView: View {
+        let title: String
+        let data: [any IconRepresentable]
+        
+        var body: some View {
+            VStack(alignment: .leading) {
+                Text(title)
+                    .font(.title)
+                ForEach(data.indices, id: \.self) { index in
+                    IconRowView(representable: data[index])
+                }
+            }
+        }
+    }
+    
+    private struct IconRowView: View {
+        let representable: any IconRepresentable
+        
+        var body: some View {
+            HStack {
+                Image.icon(representable)
+                    .fixedSize()
+                    .frame(width: 45, height: 45)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(.gray)
+                    )
+                Text(representable.name)
+                    .font(.pretendard(.regular, size: ._18))
+                Spacer()
+            }
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                IconSectionView(title: chevron.title, data: chevron.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: checkmark.title, data: checkmark.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: circleAlert.title, data: circleAlert.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: close.title, data: close.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: edit.title, data: edit.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: ranking.title, data: ranking.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: siren.title, data: siren.data)
+            }
+            VStack(alignment: .leading) {
+                IconSectionView(title: magnifier.title, data: magnifier.data)
+            }
+        }
+        .navigationTitle("Icon")
+        .padding()
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/IconPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/IconPreview.swift
@@ -16,74 +16,74 @@ struct IconPreview: View {
     private let chevron: IconDataSet = (
         "Chevron",
         [
-           DesignSystemKit.Icon.Chevron.upBig,
-           DesignSystemKit.Icon.Chevron.upMedium,
-           DesignSystemKit.Icon.Chevron.upSmall,
-           DesignSystemKit.Icon.Chevron.downBig,
-           DesignSystemKit.Icon.Chevron.downMedium,
-           DesignSystemKit.Icon.Chevron.downSmall,
-           DesignSystemKit.Icon.Chevron.leftBig,
-           DesignSystemKit.Icon.Chevron.leftMedium,
-           DesignSystemKit.Icon.Chevron.leftSmall,
-           DesignSystemKit.Icon.Chevron.rightBig,
-           DesignSystemKit.Icon.Chevron.rightMedium,
-           DesignSystemKit.Icon.Chevron.rightSmall
+           Icon.Chevron.upBig,
+           Icon.Chevron.upMedium,
+           Icon.Chevron.upSmall,
+           Icon.Chevron.downBig,
+           Icon.Chevron.downMedium,
+           Icon.Chevron.downSmall,
+           Icon.Chevron.leftBig,
+           Icon.Chevron.leftMedium,
+           Icon.Chevron.leftSmall,
+           Icon.Chevron.rightBig,
+           Icon.Chevron.rightMedium,
+           Icon.Chevron.rightSmall
        ]
     )
     
     private let checkmark: IconDataSet = (
         "Checkmark",
         [
-            DesignSystemKit.Icon.Checkmark.trueFill24,
-            DesignSystemKit.Icon.Checkmark.trueFill20,
-            DesignSystemKit.Icon.Checkmark.falseLine24,
-            DesignSystemKit.Icon.Checkmark.falseLine20,
-            DesignSystemKit.Icon.Checkmark.falseFill24,
-            DesignSystemKit.Icon.Checkmark.falseFill20
+            Icon.Checkmark.trueFill24,
+            Icon.Checkmark.trueFill20,
+            Icon.Checkmark.falseLine24,
+            Icon.Checkmark.falseLine20,
+            Icon.Checkmark.falseFill24,
+            Icon.Checkmark.falseFill20
         ]
     )
     
     private let circleAlert: IconDataSet = (
         "CircleAlert",
         [
-            DesignSystemKit.Icon.CircleAlert.fillMono
+            Icon.CircleAlert.fillMono
         ]
     )
     
     private let close: IconDataSet = (
         "Close",
         [
-            DesignSystemKit.Icon.Close.fillBlack,
-            DesignSystemKit.Icon.Close.fillGray,
+            Icon.Close.fillBlack,
+            Icon.Close.fillGray,
         ]
     )
     
     private let edit: IconDataSet = (
         "Edit",
         [
-            DesignSystemKit.Icon.Edit.list
+            Icon.Edit.list
         ]
     )
     
     private let ranking: IconDataSet = (
         "Ranking",
         [
-            DesignSystemKit.Icon.Ranking.down,
-            DesignSystemKit.Icon.Ranking.up,
+            Icon.Ranking.down,
+            Icon.Ranking.up,
         ]
     )
     
     private let siren: IconDataSet = (
         "Siren",
         [
-            DesignSystemKit.Icon.Siren.mono
+            Icon.Siren.mono
         ]
     )
     
     private let magnifier: IconDataSet = (
         "Magnifier",
         [
-            DesignSystemKit.Icon.Magnifier.lineGray
+            Icon.Magnifier.lineGray
         ]
     )
     
@@ -107,7 +107,7 @@ struct IconPreview: View {
         
         var body: some View {
             HStack {
-                Image.icon(representable)
+                Image(representable)
                     .fixedSize()
                     .frame(width: 45, height: 45)
                     .background(


### PR DESCRIPTION

# 개요
- 🔗  이슈링크 : #8 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* DesignSystem에 앱 전체에서 사용될 Icon 등록 및 Image의 Extension으로 사용할 수 있도록 기능 구현
* 아래와 같이 사용할 수 있습니다.
```swift 
import DesignSystemKit

Image( {아이콘 namespace} )

Image(Icon.Chevron.upBig)
Image(Icon.Chevron.upMedium)

Image(Icon.Checkmark.trueFill24)
Image(Icon.Checkmark.falseLine20)
```


### 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->
스크린샷 1|스크린샷2|스크린샷3
---|---|---
![Simulator Screenshot - iPhone 14 Pro - 2023-05-29 at 14 27 55](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/e2644afb-fbc2-45ed-912d-f0dc058e97b8)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-29 at 14 27 59](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/cdfe5552-b3da-49f1-b166-963945f6af41)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-29 at 14 28 03](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/af5bb655-5645-48b3-b5d4-f07600e0a299)