### PR TITLE
[DA] WQSearchBar, WQTopBar 구현

### DIFF
--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQSearchBar.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQSearchBar.swift
@@ -1,0 +1,69 @@
+//
+//  WQSearchBar.swift
+//  DesignSystemUI
+//
+//  Created by AhnSangHoon on 2023/06/06.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public struct WQSearchBar: View {
+    @Binding var input: String
+    @Binding var placeholder: String
+    
+    var onSubmit: (() -> Void)?
+    
+    public init(
+        input: Binding<String>,
+        placeholder: Binding<String>,
+        onSubmit: (() -> Void)? = nil
+    ) {
+        self._input = input
+        self._placeholder = placeholder
+        self.onSubmit = onSubmit
+    }
+    
+    public var body: some View {
+        ZStack {
+            TextField(
+                "WQSearchBar",
+                text: $input,
+                prompt:
+                    Text($placeholder.wrappedValue)
+                    .foregroundColor(.designSystem(.g4))
+            )
+            .onSubmit {
+                onSubmit?()
+            }
+            .foregroundColor(.designSystem(.g9))
+            .padding(
+                .init(
+                    top: 8,
+                    leading: 16,
+                    bottom: 8,
+                    trailing: 16
+                )
+            )
+            .clearButton(
+                .init(textFieldInput: $input, image: Image(Icon.Close.fillBlack))
+            )
+            .tint(.designSystem(.main))
+            
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 30)
+                .foregroundColor(.designSystem(.g2))
+        )
+    }
+}
+
+
+struct WQSearchBar_Previews: PreviewProvider {
+    static var previews: some View {
+        WQSearchBar(
+            input: .init(projectedValue: .constant("")),
+            placeholder: .init(projectedValue: .constant("Placeholder"))
+        )
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQTopBar.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQTopBar.swift
@@ -1,0 +1,309 @@
+//
+//  WQTopBar.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/06/03.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public struct WQTopBar: View {
+    public enum Style {
+        case title(TitleNavigationModel)
+        case navigation(TitleNavigationModel)
+        case navigationSearchBar(SearchBarNavigationModel)
+        case navigationWithButtons(ButtonNavigationModel)
+        case navigationWithListEdit(ListEditNavigationModel)
+        
+        public struct TitleNavigationModel {
+            let title: String
+            let action: (() -> Void)?
+            
+            public init(
+                title: String,
+                action: (() -> Void)? = nil
+            ) {
+                self.title = title
+                self.action = action
+            }
+        }
+        
+        public struct ButtonNavigationModel {
+            public struct Button {
+                let icon: any IconRepresentable
+                let action: (() -> Void)?
+                
+                public init(
+                    icon: any IconRepresentable,
+                    action: (() -> Void)? = nil
+                ) {
+                    self.icon = icon
+                    self.action = action
+                }
+            }
+            let title: String
+            let bttons: [Button]
+            let action: (() -> Void)?
+            
+            public init(
+                title: String,
+                bttons: [Button],
+                action: (() -> Void)? = nil
+            ) {
+                self.title = title
+                self.bttons = bttons
+                self.action = action
+            }
+        }
+        
+        public struct SearchBarNavigationModel {
+            @Binding var placeholder: String
+            @Binding var input: String
+            @Binding var isEditing: Bool
+            let action: (() -> Void)?
+            let onSubmit: (() -> Void)?
+            
+            public init(
+                placeholder: Binding<String>,
+                input: Binding<String>,
+                isEditing: Binding<Bool>,
+                action: (() -> Void)? = nil,
+                onSubmit: (() -> Void)? = nil
+            ) {
+                self._placeholder = placeholder
+                self._input = input
+                self._isEditing = isEditing
+                self.action = action
+                self.onSubmit = onSubmit
+            }
+        }
+        
+        public struct ListEditNavigationModel {
+            let buttonTitle: String = "순서 편집"
+            let buttonNavigationModel: ButtonNavigationModel
+            
+            public init(title: String, editAction: @escaping (() -> Void), action: (() -> Void)?) {
+                self.buttonNavigationModel = ButtonNavigationModel(
+                    title: title,
+                    bttons: [
+                        .init(
+                            icon: Icon.Edit.list,
+                            action: editAction
+                        )
+                    ],
+                    action: action
+                )
+            }
+        }
+    }
+    
+    public let style: Style
+    
+    public init(style: Style) {
+        self.style = style
+    }
+    
+    public var body: some View {
+        switch style {
+        case .title(let model):
+            title(model)
+        case .navigation(let model):
+            navigation(model)
+        case .navigationSearchBar(let model):
+            navigation(model)
+        case .navigationWithButtons(let model):
+            navigation(model)
+        case .navigationWithListEdit(let model):
+            navigation(model)
+        }
+    }
+    
+    private func title(_ model: Style.TitleNavigationModel) -> some View {
+        ZStack {
+            HStack(spacing: .zero) {
+                Text(model.title)
+                    .font(.pretendard(.bold, size: ._18))
+                Spacer()
+            }
+            .padding(
+                EdgeInsets(
+                    top: 15,
+                    leading: 12,
+                    bottom: 15,
+                    trailing: 0
+                )
+            )
+        }
+    }
+    
+    private func navigation(_ model: Style.TitleNavigationModel) -> some View {
+        ZStack {
+            HStack(spacing: .zero) {
+                Button {
+                    model.action?()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(Icon.Chevron.leftBig)
+                        Text(model.title)
+                            .font(.pretendard(.bold, size: ._18))
+                            .foregroundColor(.designSystem(.g2))
+                    }
+                }
+                Spacer()
+            }
+            .padding(
+                EdgeInsets(
+                    top: 15,
+                    leading: 12,
+                    bottom: 15,
+                    trailing: 0
+                )
+            )
+        }
+    }
+    
+    private func navigation(_ model: Style.ButtonNavigationModel) -> some View {
+        ZStack {
+            HStack(spacing: .zero) {
+                Button {
+                    model.action?()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(Icon.Chevron.leftBig)
+                        Text(model.title)
+                            .font(.pretendard(.bold, size: ._18))
+                            .foregroundColor(.designSystem(.g2))
+                    }
+                }
+                Spacer()
+                HStack {
+                    ForEach(model.bttons.indices, id:\.self) { index in
+                        let buttonConfigure = model.bttons[index]
+                        Button {
+                            buttonConfigure.action?()
+                        } label: {
+                            Image(buttonConfigure.icon)
+                        }
+                    }
+                }
+            }
+            .padding(
+                EdgeInsets(
+                    top: 15,
+                    leading: 12,
+                    bottom: 15,
+                    trailing: 0
+                )
+            )
+        }
+    }
+    
+    private func navigation(_ model: Style.SearchBarNavigationModel) -> some View {
+        ZStack {
+            HStack(spacing: 12) {
+                Button {
+                    model.action?()
+                } label: {
+                    Image(Icon.Chevron.leftBig)
+                }
+                WQSearchBar(
+                    input: model.$input,
+                    placeholder: model.$placeholder,
+                    onSubmit: model.onSubmit
+                )
+            }
+            .padding(
+                EdgeInsets(
+                    top: 15,
+                    leading: 12,
+                    bottom: 15,
+                    trailing: 0
+                )
+            )
+        }
+    }
+    
+    private func navigation(_ model: Style.ListEditNavigationModel) -> some View {
+        ZStack {
+            HStack(spacing: .zero) {
+                Button {
+                    model.buttonNavigationModel.action?()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(Icon.Chevron.leftBig)
+                        Text(model.buttonNavigationModel.title)
+                            .font(.pretendard(.bold, size: ._18))
+                            .lineLimit(1)
+                            .foregroundColor(.designSystem(.g2))
+                    }
+                }
+                Spacer()
+                if let editButtonModel = model.buttonNavigationModel.bttons.first {
+                    Button {
+                        editButtonModel.action?()
+                    } label: {
+                        HStack(spacing: 2) {
+                            Image(editButtonModel.icon)
+                                .renderingMode(.template)
+                            Text(model.buttonTitle)
+                                .font(.pretendard(.regular, size: ._16))
+                        }
+                        .foregroundColor(.designSystem(.g2))
+                    }
+                }
+            }
+            .padding(
+                EdgeInsets(
+                    top: 15,
+                    leading: 12,
+                    bottom: 15,
+                    trailing: 0
+                )
+            )
+        }
+    }
+}
+
+struct WQTopBar_Previews: PreviewProvider {
+    static var previews: some View {
+        WQTopBar(style: .title(.init(title: "타이트으으을")))
+        WQTopBar(style: .navigation(.init(title: "타이트으으을", action: {
+            print("타이틀 네비게이션 탑바 뒤로가기 클릭")
+        })))
+        WQTopBar(style: .navigationWithButtons(
+            .init(
+                title: "네비게이션 With Buttons",
+                bttons: [
+                    .init(icon: Icon.Magnifier.lineGray, action: {
+                        print("돋보기 버튼 클릭")
+                    }),
+                    .init(icon: Icon.CircleAlert.fillMono, action: {
+                        print("이상한버튼 클릭")
+                    })
+                ],
+                action: {
+                    print("타이틀 네비게이션 탑바 withButton 뒤로가기 클릭")
+                }
+            ))
+        )
+        WQTopBar(style: .navigationSearchBar(
+            .init(
+                placeholder: .init(projectedValue: .constant("placeholder")),
+                input: .init(projectedValue: .constant("")),
+                isEditing: .init(projectedValue: .constant(false)),
+                action: {
+                    print("네비게이션 탑바 withSearchBar 뒤로가기 클릭")
+                })
+        ))
+        WQTopBar(style: .navigationWithListEdit(
+            .init(
+                title: "네비게이션 With List Edit",
+                editAction: {
+                    print("리스트 편집 활성화")
+                }, action: {
+                    print("네비게이션 탑바 withListEdit 뒤로가기 클릭")
+                })
+        ))
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/View+ClearButton.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/View+ClearButton.swift
@@ -1,0 +1,41 @@
+//
+//  View+ClearButton.swift
+//  DesignSystemUI
+//
+//  Created by AhnSangHoon on 2023/06/06.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public struct ClearButton: ViewModifier {
+    @Binding var textFieldInput: String
+    let image: Image
+    
+    public init(textFieldInput: Binding<String>, image: Image) {
+        self._textFieldInput = textFieldInput
+        self.image = image
+    }
+    
+    public func body(content: Content) -> some View {
+        ZStack(alignment: .trailing) {
+            content
+            if !textFieldInput.isEmpty {
+                Button {
+                    textFieldInput = ""
+                } label: {
+                    Image(Icon.Close.fillBlack)
+                }
+                .padding(.trailing, 8)
+            }
+        }
+    }
+}
+
+public extension View {
+    func clearButton(_ button: ClearButton) -> some View {
+        modifier(
+            button
+        )
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/ComponentPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/ComponentPreview.swift
@@ -13,7 +13,11 @@ import DesignSystemKit
 struct ComponentPreview: View {
     var body: some View {
         ScrollView {
-            WQButtonPreview()
+            VStack {
+                WQButtonPreview()
+                WQSearchBarPreview()
+                WQTopBarPreview()
+            }
         }
         .navigationTitle("Component")
         .padding()

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQSearchBarPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQSearchBarPreview.swift
@@ -1,0 +1,36 @@
+//
+//  WQSearchBarPreview.swift
+//  DesignSystemUI
+//
+//  Created by AhnSangHoon on 2023/06/06.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+import DesignSystemKit
+
+struct WQSearchBarPreview: View {
+    @State var input1: String = ""
+    @State var input2: String = ""
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("SearchBar")
+                .font(.title)
+            VStack(alignment: .center) {
+                WQSearchBar(
+                    input: $input1,
+                    placeholder: .init(projectedValue: .constant("Placeholder"))
+                )
+                WQSearchBar(
+                    input: $input2,
+                    placeholder: .init(projectedValue: .constant("Placeholder")),
+                    onSubmit: {
+                        print("엔터버튼 눌렀을 때")
+                    }
+                )
+            }
+        }
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQTopBarPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQTopBarPreview.swift
@@ -1,0 +1,59 @@
+//
+//  WQTopBarPreview.swift
+//  DesignSystemUI
+//
+//  Created by AhnSangHoon on 2023/06/06.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+import DesignSystemKit
+
+struct WQTopBarPreview: View {
+    @State var searchBarInput: String = ""
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("TopBar")
+                .font(.title)
+            VStack {
+                WQTopBar(style: .title(.init(title: "타이틀만")))
+                WQTopBar(style: .navigation(.init(title: "네비게이션이랑 타이틀")))
+                WQTopBar(style: .navigationWithButtons(
+                    .init(
+                        title: "네비게이션이랑 버튼",
+                        bttons: [
+                            .init(icon: Icon.Edit.list, action: {
+                                print("네비게이션 버튼 클릭1")
+                            }),
+                            .init(icon: Icon.CircleAlert.fillMono, action: {
+                                print("네비게이션 버튼 클릭2")
+                            })
+                        ]
+                    )
+                ))
+                WQTopBar(style: .navigationSearchBar(
+                    .init(
+                        placeholder: .init(projectedValue: .constant("placeholder")),
+                        input: $searchBarInput,
+                        isEditing: .init(projectedValue: .constant(false)),
+                        action: {
+                            print("네비게이션 탑바 withSearchBar 뒤로가기 클릭")
+                        }, onSubmit: {
+                            print("엔터버튼 누를시!")
+                        })
+                ))
+                WQTopBar(style: .navigationWithListEdit(
+                    .init(
+                        title: "네비게이션 With List Edit",
+                        editAction: {
+                            print("리스트 편집 활성화")
+                        }, action: {
+                            print("네비게이션 탑바 withListEdit 뒤로가기 클릭")
+                        })
+                ))
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 :  #8 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->

- 공통으로 사용될 WQSearchBar, WQTopBar를 구현하고, Preview를 작성하였습니다.
- WQSearchBar는 ClearButton까지 적용되어있습니다.
 추가로 다른곳에서도 ClearButton을 추가할 수 있도록 View Extension을 작성하였습니다.
- 각각의 사용방법은 아래와 같습니다.

```swift

/// WQSearchBar

@State var input1: String = ""
@State var input2: String = ""

WQSearchBar(
    input: $input1,
    placeholder: .init(projectedValue: .constant("Placeholder"))
)
WQSearchBar(
    input: $input2,
    placeholder: .init(projectedValue: .constant("Placeholder")),
    onSubmit: {
        print("엔터버튼 눌렀을 때")
    }
)

/// WQTopBar

WQTopBar(style: .title(.init(title: "타이틀만")))

WQTopBar(style: .navigation(.init(title: "네비게이션이랑 타이틀")))

WQTopBar(style: .navigationWithButtons(
    .init(
        title: "네비게이션이랑 버튼",
        bttons: [
            .init(icon: Icon.Edit.list, action: {
                print("네비게이션 버튼 클릭1")
            }),
            .init(icon: Icon.CircleAlert.fillMono, action: {
                print("네비게이션 버튼 클릭2")
            })
        ]
    )
))

@State var searchBarInput: String = ""
WQTopBar(style: .navigationSearchBar(
    .init(
        placeholder: .init(projectedValue: .constant("placeholder")),
        input: $searchBarInput,
        isEditing: .init(projectedValue: .constant(false)),
        action: {
            print("네비게이션 탑바 withSearchBar 뒤로가기 클릭")
        }, onSubmit: {
            print("엔터버튼 누를시!")
        })
))

WQTopBar(style: .navigationWithListEdit(
    .init(
        title: "네비게이션 With List Edit",
        editAction: {
            print("리스트 편집 활성화")
        }, action: {
            print("네비게이션 탑바 withListEdit 뒤로가기 클릭")
        })
))

```


### 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->

<img src="https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/ae4d7236-993f-4acd-a90c-c30405f44b95" width="414" height="896">



