### PR TITLE
[DA] WQModal 구현

### DIFF
--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQButton.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQButton.swift
@@ -15,7 +15,7 @@ public struct WQButton: View {
         case fullRadiusSingle(SingleButtonStyleModel)
     }
     
-    public let style: Style
+    private let style: Style
     
     public init(style: Style) {
         self.style = style
@@ -34,14 +34,19 @@ public struct WQButton: View {
     
     private func twoButton(_ style: Style, model: Style.DobuleButtonStyleModel) -> some View {
         ZStack {
-            HStack {
+            HStack(spacing: 7) {
                 Button {
                     model.leftAction?()
                 } label: {
-                    Text(model.titles.leftTitle)
-                        .font(.pretendard(.semibold, size: ._16))
-                        .foregroundColor(.designSystem(.g2))
-                        .padding()
+                    HStack(spacing: .zero) {
+                        Spacer()
+                        Text(model.titles.leftTitle)
+                            .font(.pretendard(.semibold, size: ._16))
+                            .lineLimit(1)
+                            .foregroundColor(.designSystem(.g2))
+                            .padding()
+                        Spacer()
+                    }
                 }
                 .background {
                     RoundedRectangle(cornerRadius: style.cornerRadius)
@@ -50,10 +55,15 @@ public struct WQButton: View {
                 Button {
                     model.rightAction?()
                 } label: {
-                    Text(model.titles.rightTitle)
-                        .font(.pretendard(.semibold, size: ._16))
-                        .foregroundColor(.designSystem(.g2))
-                        .padding()
+                    HStack(spacing: .zero) {
+                        Spacer()
+                        Text(model.titles.rightTitle)
+                            .font(.pretendard(.semibold, size: ._16))
+                            .lineLimit(1)
+                            .foregroundColor(.designSystem(.g2))
+                            .padding()
+                        Spacer()
+                    }
                 }
                 .background {
                     RoundedRectangle(cornerRadius: style.cornerRadius)

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQModal.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQModal.swift
@@ -1,0 +1,156 @@
+//
+//  WQModal.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/06/10.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public struct WQModal: View {
+    public enum Style {
+        case oneButton(OneButtonAlertModel)
+        case twoButton(TwoButtonAlertModel)
+        
+        public struct OneButtonAlertModel {
+            let message: String
+            let singleButtonStyleModel: WQButton.Style.SingleButtonStyleModel
+            
+            public init(message: String, singleButtonStyleModel: WQButton.Style.SingleButtonStyleModel) {
+                self.message = message
+                self.singleButtonStyleModel = singleButtonStyleModel
+            }
+        }
+        
+        public struct TwoButtonAlertModel {
+            let message: String
+            let doubleButtonStyleModel: WQButton.Style.DobuleButtonStyleModel
+            
+            public init(message: String, doubleButtonStyleModel: WQButton.Style.DobuleButtonStyleModel) {
+                self.message = message
+                self.doubleButtonStyleModel = doubleButtonStyleModel
+            }
+        }
+    }
+    
+    private let style: Style
+    @Binding private var isPresented: Bool
+    
+    public init(style: Style, isPresented: Binding<Bool>) {
+        self.style = style
+        self._isPresented = isPresented
+    }
+    
+    public var body: some View {
+        switch style {
+        case .oneButton(let oneButtonAlertModel):
+            modal(oneButtonAlertModel)
+        case .twoButton(let twoButtonAlertModel):
+            modal(twoButtonAlertModel)
+        }
+    }
+    
+    private struct DimView: View {
+        @Binding var isPresented: Bool
+        
+        var body: some View {
+            Color.designSystem(.dimed)
+                .opacity(0.8)
+                .onTapGesture {
+                    isPresented = false
+                }
+        }
+    }
+    
+    private func modal(_ model: Style.OneButtonAlertModel) -> some View {
+        GeometryReader { proxy in
+            if isPresented {
+                ZStack {
+                    DimView(isPresented: $isPresented)
+                    VStack(spacing: .zero) {
+                        HStack {
+                            Text(model.message)
+                                .multilineTextAlignment(.center)
+                                .font(.pretendard(.regular, size: ._16))
+                        }
+                        .padding(
+                            .init(
+                                top: 40,
+                                leading: 12,
+                                bottom: 40,
+                                trailing: 12
+                            )
+                        )
+                        WQButton(style: .single(model.singleButtonStyleModel))
+                            .frame(maxWidth: proxy.size.width * 0.8)
+                    }
+                    .background {
+                        RoundedRectangle(cornerRadius: 16)
+                            .foregroundColor(.designSystem(.g7))
+                    }
+                }
+                .position(x: proxy.size.width / 2.0, y: proxy.size.height / 2.0)
+            }
+        }
+    }
+    
+    private func modal(_ model: Style.TwoButtonAlertModel) -> some View {
+        GeometryReader { proxy in
+            if isPresented {
+                ZStack {
+                    DimView(isPresented: $isPresented)
+                    VStack(spacing: .zero) {
+                        HStack {
+                            Text(model.message)
+                                .multilineTextAlignment(.center)
+                                .font(.pretendard(.regular, size: ._16))
+                        }
+                        .padding(
+                            .init(
+                                top: 40,
+                                leading: 12,
+                                bottom: 40,
+                                trailing: 12
+                            )
+                        )
+                        WQButton(style: .double(model.doubleButtonStyleModel))
+                            .frame(maxWidth: proxy.size.width * 0.8)
+                    }
+                    .background {
+                        RoundedRectangle(cornerRadius: 16)
+                            .foregroundColor(.designSystem(.g7))
+                    }
+                }
+                .position(x: proxy.size.width / 2.0, y: proxy.size.height / 2.0)
+            }
+        }
+    }
+}
+
+struct WQModal_Previews: PreviewProvider {
+    static var previews: some View {
+        WQModal(style: .oneButton(.init(
+            message: "WQ Modal\nOne ButtonOne ButtonOne Button",
+            singleButtonStyleModel: .init(
+                title: "버튼",
+                action: {
+                    print("버튼클릭")
+                })
+        )), isPresented: .init(projectedValue: .constant(true))
+        )
+        WQModal(style: .twoButton(
+            .init(
+                message: "WQ Modal\nTwo Button",
+                doubleButtonStyleModel: .init(
+                    titles: (leftTitle: "왼쪽", rightTitle: "오른쪽"),
+                    leftAction: {
+                        print("왼쪽버튼클릭")
+                    }, rightAction: {
+                        print("오른쪽버튼클릭")
+                    }
+                )
+            )), isPresented: .init(projectedValue: .constant(true))
+        )
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/View+Modal.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/View+Modal.swift
@@ -1,0 +1,55 @@
+//
+//  View+Modal.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/06/10.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public struct OneButtonModalModifier: ViewModifier {
+    private let model: WQModal.Style.OneButtonAlertModel
+    @Binding var isPresented: Bool
+    
+    public init(model: WQModal.Style.OneButtonAlertModel, isPresented: Binding<Bool>) {
+        self.model = model
+        self._isPresented = isPresented
+    }
+    
+    public func body(content: Content) -> some View {
+        ZStack {
+            content
+            WQModal(style: .oneButton(model), isPresented: $isPresented)
+                .edgesIgnoringSafeArea(.all)
+        }
+    }
+}
+
+public struct TwoButtonModalModifier: ViewModifier {
+    private let model: WQModal.Style.TwoButtonAlertModel
+    @Binding var isPresented: Bool
+    
+    public init(model: WQModal.Style.TwoButtonAlertModel, isPresented: Binding<Bool>) {
+        self.model = model
+        self._isPresented = isPresented
+    }
+    
+    public func body(content: Content) -> some View {
+        ZStack {
+            content
+            WQModal(style: .twoButton(model), isPresented: $isPresented)
+                .edgesIgnoringSafeArea(.all)
+        }
+    }
+}
+
+public extension View {
+    func modal(_ style: WQModal.Style.OneButtonAlertModel, isPresented: Binding<Bool>) -> some View {
+        modifier(OneButtonModalModifier(model: style, isPresented: isPresented))
+    }
+    
+    func modal(_ style: WQModal.Style.TwoButtonAlertModel, isPresented: Binding<Bool>) -> some View {
+        modifier(TwoButtonModalModifier(model: style, isPresented: isPresented))
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/ComponentPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/ComponentPreview.swift
@@ -19,7 +19,13 @@ struct ComponentPreview: View {
                 WQTopBarPreview()
             }
         }
+        .safeAreaInset(
+            edge: .bottom,
+            content: {
+                Spacer()
+                    .frame(height: 15)
+            }
+        )
         .navigationTitle("Component")
-        .padding()
     }
 }

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQModalPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQModalPreview.swift
@@ -1,0 +1,61 @@
+//
+//  WQModalPreview.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/06/10.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+import DesignSystemKit
+
+struct WQModalPreview: View {
+    @State private var oneButtonModalIsPresent: Bool = false
+    @State private var twoButtonModalIsPresent: Bool = false
+    
+    var body: some View {
+        ZStack {
+            VStack(alignment: .leading) {
+                Text("Modal")
+                    .font(.title)
+                Button("OneButton Modal") {
+                    oneButtonModalIsPresent = true
+                }
+                Button("TwoButton Modal") {
+                    twoButtonModalIsPresent = true
+                }
+            }
+        }
+        .modal(
+            .init(
+                message: "원버튼 모달",
+                singleButtonStyleModel: .init(
+                    title: "버튼 타이틀",
+                    action: {
+                        print("버튼이 눌렸넹")
+                        oneButtonModalIsPresent = false
+                    }
+                )
+            ),
+            isPresented: $oneButtonModalIsPresent
+        )
+        .modal(
+            .init(
+                message: "투버튼 모달",
+                doubleButtonStyleModel: .init(
+                    titles: ("왼쪽버튼타이틀", "오른쪽버튼 타이틀"),
+                    leftAction: {
+                        print("왼쪽버튼이 눌렸넹")
+                        twoButtonModalIsPresent = false
+                    },
+                    rightAction: {
+                        print("오른쪽버튼이 눌렸넹")
+                        twoButtonModalIsPresent = false
+                    }
+                )
+            ),
+            isPresented: $twoButtonModalIsPresent
+        )
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ContentView.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ContentView.swift
@@ -13,6 +13,7 @@ public struct ContentView: View {
         case icon
         case color
         case component
+        case modal
     }
 
     public var body: some View {
@@ -23,6 +24,7 @@ public struct ContentView: View {
                 NavigationLink("Icon", value: NavigationType.icon)
                 NavigationLink("Color", value: NavigationType.color)
                 NavigationLink("Component", value: NavigationType.component)
+                NavigationLink("Modal", value: NavigationType.modal)
             }
             .navigationDestination(for: NavigationType.self) {
                 switch $0 {
@@ -34,6 +36,8 @@ public struct ContentView: View {
                     ColorPreview()
                 case .component:
                     ComponentPreview()
+                case .modal:
+                    WQModalPreview()
                 }
             }
             .navigationTitle("WeQuiz DesignSystem")


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #8 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 공통으로 사용될 WQModal을 구현하고, Preview를 작성하였습니다.
* 사용방법은 다음과 같습니다.
```swift

TopLevelView
    .modal(
        .init(
            message: "원버튼 모달",
            singleButtonStyleModel: .init(
                title: "버튼 타이틀",
                action: {
                    print("버튼이 눌렸넹")
                    oneButtonModalIsPresent = false
                }
            )
        ),
        isPresented: $oneButtonModalIsPresent
    )

TopLevelView
    .modal(
        .init(
            message: "투버튼 모달",
            doubleButtonStyleModel: .init(
                titles: ("왼쪽버튼타이틀", "오른쪽버튼 타이틀"),
                leftAction: {
                    print("왼쪽버튼이 눌렸넹")
                    twoButtonModalIsPresent = false
                },
                rightAction: {
                    print("오른쪽버튼이 눌렸넹")
                    twoButtonModalIsPresent = false
                }
            )
        ),
        isPresented: $twoButtonModalIsPresent
    )

```
* ⚠️ 사용시 주의사항
  * `.modal` modifier는 가장 최상위 뷰에 사용해야 합니다.


### 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->

### 변경 전
OneButtonModal|TwoButtonModal
---|---
![Simulator Screenshot - iPhone 14 Pro - 2023-06-11 at 15 30 57](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/24881ac3-2716-4a74-adb9-4b142287cb93)|![Simulator Screenshot - iPhone 14 Pro - 2023-06-11 at 15 31 00](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/0d1db316-a514-4115-9640-7d08ed597b35)

### 변경 이후

OneButtonModal|TwoButtonModal
---|---
![Simulator Screenshot - iPhone 14 Pro - 2023-06-17 at 21 48 08](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/07589711-62f9-48c1-a0c1-41035e433f82)|![Simulator Screenshot - iPhone 14 Pro - 2023-06-17 at 21 48 04](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/1f42d5cc-9a76-46ae-b3ee-db848f663c87)

