### PR TITLE
[DA] button height 수정(#37)

### DIFF
--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQButton.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQButton.swift
@@ -52,6 +52,7 @@ public struct WQButton: View {
                     RoundedRectangle(cornerRadius: style.cornerRadius)
                         .foregroundColor(.designSystem(.g5))
                 }
+                .frame(height: 52)
                 Button {
                     model.rightAction?()
                 } label: {
@@ -69,6 +70,7 @@ public struct WQButton: View {
                     RoundedRectangle(cornerRadius: style.cornerRadius)
                         .foregroundColor(.designSystem(.p1))
                 }
+                .frame(height: 52)
             }
             .padding(style.padding)
         }
@@ -85,6 +87,7 @@ public struct WQButton: View {
                     .padding()
                     .frame(maxWidth: .infinity)
             }
+            .frame(height: 52)
             .frame(maxWidth: .infinity)
             .background {
                 RoundedRectangle(cornerRadius: style.cornerRadius)
@@ -105,6 +108,7 @@ public struct WQButton: View {
                     .padding()
                     .frame(maxWidth: .infinity)
             }
+            .frame(height: 52)
             .frame(maxWidth: .infinity)
             .background {
                 RoundedRectangle(cornerRadius: style.cornerRadius)


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #37 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
- button height 52로 고정

### 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->
작업 전|작업 후
---|---
![#37_작업전](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/575eda5f-58e9-4458-8339-523033d2ab65)|![#37_작업후](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/dd5d38d3-d23e-408f-96b3-1c0c4645549a)




