### PR TITLE
[DA] Gradient Color 추가 및 WQGradientProgressBar 구현

### DIFF
--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Colors.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Colors.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 ommaya.io. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
 
 public extension DesignSystemKit {
     enum Colors: String, CaseIterable {
@@ -43,9 +43,99 @@ public extension DesignSystemKit {
         // MARK: - Opacity
         
         case dimed
-                
+
         public var name: String {
             self.rawValue
+        }
+    }
+}
+
+public extension DesignSystemKit {
+    enum Gradient: String, CaseIterable {
+        
+        // MARK: - Gradient
+        
+        case gradientS1
+        case gradientS2
+        case gradientS3
+        case gradientS4
+        case gradientS5
+        
+        public var stops: [SwiftUI.Gradient.Stop] {
+            switch self {
+            case .gradientS1:
+                return [
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.8, green: 0.98, blue: 1), location: 0.00),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.43, green: 0.92, blue: 0.95), location: 0.41),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.42, green: 0.95, blue: 0.73), location: 1.00)
+                ]
+            case .gradientS2:
+                return [
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.86, green: 0.95, blue: 1), location: 0.00),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.56, green: 0.79, blue: 1), location: 0.48),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.45, green: 0.82, blue: 0.79), location: 1.00)
+                ]
+            case .gradientS3:
+                return [
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.87, green: 0.9, blue: 1), location: 0.00),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.68, green: 0.67, blue: 1), location: 0.46),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.48, green: 0.68, blue: 0.84), location: 1.00)
+                ]
+            case .gradientS4:
+                return [
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.89, green: 0.85, blue: 1), location: 0.00),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.77, green: 0.58, blue: 1), location: 0.47),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.51, green: 0.55, blue: 0.89), location: 1.00)
+                ]
+            case .gradientS5:
+                return [
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.95, green: 0.85, blue: 1), location: 0.00),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.86, green: 0.56, blue: 1), location: 0.41),
+                    SwiftUI.Gradient.Stop(color: Color(red: 0.54, green: 0.41, blue: 0.95), location: 1.00)
+                ]
+            }
+        }
+        
+        public var name: String {
+            self.rawValue
+        }
+        
+        public var startPont: UnitPoint {
+            switch self {
+            case .gradientS1:
+                return UnitPoint(x: 0.01, y: 0.81)
+            case .gradientS2:
+                return UnitPoint(x: 0.01, y: 0.81)
+            case .gradientS3:
+                return UnitPoint(x: 0.01, y: 0.81)
+            case .gradientS4:
+                return UnitPoint(x: 0.01, y: 0.81)
+            case .gradientS5:
+                return UnitPoint(x: 0.04, y: 1)
+            }
+        }
+        
+        public var endtPont: UnitPoint {
+            switch self {
+            case .gradientS1:
+                return UnitPoint(x: 0.72, y: 0.21)
+            case .gradientS2:
+                return UnitPoint(x: 0.72, y: 0.21)
+            case .gradientS3:
+                return UnitPoint(x: 0.72, y: 0.21)
+            case .gradientS4:
+                return UnitPoint(x: 0.72, y: 0.21)
+            case .gradientS5:
+                return UnitPoint(x: 0.66, y: 0)
+            }
+        }
+        
+        public var linearGradient: LinearGradient {
+            LinearGradient(
+                stops: self.stops,
+                startPoint: self.startPont,
+                endPoint: self.endtPont
+            )
         }
     }
 }

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQGradientProgressBar.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Components/WQGradientProgressBar.swift
@@ -1,0 +1,59 @@
+//
+//  WQGradientProgressBar.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/07/01.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public struct WQGradientProgressBar: View {
+    private struct WQProgressViewStyle: ProgressViewStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            let fractionCompleted = configuration.fractionCompleted ?? 0
+            ZStack(alignment: .topLeading) {
+                GeometryReader { proxy in
+                    Rectangle()
+                        .foregroundStyle(
+                            DesignSystemKit.Gradient.gradientS1.linearGradient
+                        )
+                        .frame(
+                            maxWidth: proxy.size.width * CGFloat(fractionCompleted)
+                        )
+                }
+            }
+        }
+    }
+
+    private let standard: Int
+    @Binding private var current: Int
+    @State private var width: CGFloat = .infinity
+    
+    public init(
+        standard: Int,
+        current: Binding<Int>
+    ) {
+        self.standard = standard
+        self._current = current
+    }
+    
+    public var body: some View {
+        ZStack {
+            Rectangle()
+                .frame(height: 2)
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.designSystem(.g8))
+            ProgressView(value: CGFloat(current), total: CGFloat(standard))
+                .frame(height: 2)
+                .progressViewStyle(WQProgressViewStyle())
+        }
+        .animation(.easeInOut, value: current)
+    }
+}
+
+struct WQGradientProgressBar_Previews: PreviewProvider {
+    static var previews: some View {
+        WQGradientProgressBar(standard: 3, current: .constant(3))
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/View+Gradient.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemKit/Sources/Extensions/View+Gradient.swift
@@ -1,0 +1,19 @@
+//
+//  View+Gradient.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/07/01.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+public extension View {
+    static func linearGradient(_ gradient: DesignSystemKit.Gradient) -> LinearGradient {
+        LinearGradient(
+            stops: gradient.stops,
+            startPoint: gradient.startPont,
+            endPoint: gradient.endtPont
+        )
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ColorPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ColorPreview.swift
@@ -12,6 +12,7 @@ import DesignSystemKit
 
 struct ColorPreview: View {
     let colorDataSet = DesignSystemKit.Colors.allCases
+    let gradientDataSet = DesignSystemKit.Gradient.allCases
     
     private struct ColorRowView: View {
         let color: DesignSystemKit.Colors
@@ -30,10 +31,32 @@ struct ColorPreview: View {
         }
     }
     
+    private struct GradientRowView: View {
+        let gradient: DesignSystemKit.Gradient
+        
+        var body: some View {
+            HStack {
+                RoundedRectangle(
+                    cornerRadius: 4
+                )
+                .foregroundStyle(
+                    gradient.linearGradient
+                )
+                .frame(width: 45, height: 45)
+                Text(gradient.name)
+                    .font(.pretendard(.regular, size: ._18))
+                Spacer()
+            }
+        }
+    }
+    
     var body: some View {
         ScrollView {
             ForEach(colorDataSet.indices, id: \.self) {
                 ColorRowView(color: colorDataSet[$0])
+            }
+            ForEach(gradientDataSet.indices, id: \.self) {
+                GradientRowView(gradient: gradientDataSet[$0])
             }
         }
         .navigationTitle("Color")

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQGradientProgressBarPreview.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/Component/WQGradientProgressBarPreview.swift
@@ -1,0 +1,37 @@
+//
+//  WQGradientProgressBarPreview.swift
+//  DesignSystemKit
+//
+//  Created by AhnSangHoon on 2023/07/02.
+//  Copyright © 2023 ommaya.io. All rights reserved.
+//
+
+import SwiftUI
+
+import DesignSystemKit
+
+struct WQGradientProgressBarPreview: View {
+    private let standard: Int = 10
+    @State private var current: Int = .zero
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("GradientProgressBar")
+                .font(.title)
+            VStack {
+                WQGradientProgressBar(
+                    standard: standard,
+                    current: $current
+                )
+                Button("버튼을 눌러보세요") {
+                    if current == standard {
+                        current = 0
+                    } else {
+                        current += 1
+                    }
+                }
+            }
+            Spacer()
+        }
+    }
+}

--- a/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ContentView.swift
+++ b/Projects/DesignSystem/Targets/DesignSystemUI/Sources/ContentView.swift
@@ -16,6 +16,7 @@ public struct ContentView: View {
         case modal
         case input
         case toast
+        case progressbar
     }
 
     public var body: some View {
@@ -29,6 +30,7 @@ public struct ContentView: View {
                 NavigationLink("Modal", value: NavigationType.modal)
                 NavigationLink("Input", value: NavigationType.input)
                 NavigationLink("Toast", value: NavigationType.toast)
+                NavigationLink("ProgressBar", value: NavigationType.progressbar)
             }
             .navigationDestination(for: NavigationType.self) {
                 switch $0 {
@@ -46,6 +48,8 @@ public struct ContentView: View {
                     WQInputFieldPreview()
                 case .toast:
                     WQToastPreview()
+                case .progressbar:
+                    WQGradientProgressBarPreview()
                 }
             }
             .navigationTitle("WeQuiz DesignSystem")


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #54 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* Gradient Color를 추가하였습니다
  * `DesignSystemKit.Gradient`에서 `.linearGradient` property로 LinearGradient Instance를 사용할 수 있습니다.
  * `DesignSystemKit.Color`와 사용방법이 다르기 때문에 (컬러 에셋을 등록하고 사용하는 방식이 아닌, 컬러값을 지정하여 LinearGradient Instance를 만들어 사용하는방식) namespace를 구분하였습니다.
* 사용방법은 아래와 같습니다.
 ```swift
SomeView()
  .foregroundStyle(
    DesignSystemKit.Gradient.gradientS1.linearGradient
  )
  ```
* WQGradientProgressBar를 구현하였습니다.
* 사용방법은 아래와 같습니다.
```swift
private let standard: Int = 10
@State private var current: Int = .zero // 해당값을 변경하면 progress가 채워집니다

WQGradientProgressBar(
    standard: standard, // progress의 총 길이
    current: $current // progress의 현재 값
)
```

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/baf627b2-0e6f-41a8-b939-44a94ef216e5
