### PR TITLE
:recycle: 퀴즈 만들기 - UI QA (#89)

### DIFF
--- a/Projects/WeQuiz/Sources/Quiz/MakeQuiz/MakeQuizView.swift
+++ b/Projects/WeQuiz/Sources/Quiz/MakeQuiz/MakeQuizView.swift
@@ -37,74 +37,41 @@ public struct MakeQuizView: View {
                 .background(
                     Color.designSystem(.g9)
                 )
-                
-                GeometryReader {_ in
-                    VStack {
-                        VStack {
-                            TextField("", text: $viewModel.quiz.title, prompt: Text("제목없는 시험지").foregroundColor(Color.designSystem(.g4)))
-                                .frame(height: 34)
-                                .onReceive(Just(viewModel.quiz.title)) { _ in
-                                    viewModel.limitQuizName()
-                                }
-                                .font(.pretendard(.medium, size: ._24))
-                                .foregroundColor(Color.designSystem(.g4))
-                                .padding(EdgeInsets(top: 24, leading: 20, bottom: 0, trailing: 20))
-                            
-                            List {
-                                Section(content: {
-                                    ForEach($viewModel.quiz.questions, id: \.id) { item in
-                                        QuestionView(model: item, onRemove: { index in
-                                            removedIndex = (popupPresented: true, index: index)
-                                        }, onExpand: { index in
-                                            viewModel.toggleExpand(index)
-                                        })
-                                    }
-                                    .onMove(perform: moveListItem)
 
-                                }, footer: {
-                                    
-                                    Button(action: {
-                                        if self.viewModel.quiz.questions.count >= 10 { return }
-                                        self.viewModel.quiz.questions.append(MakeQuestionModel())
-                                    }) {
-                                        HStack(alignment: .center, spacing: 7, content: {
-                                            Image(Icon.Add.circle)
-                                                .frame(width: 16.5, height: 16.5)
-                                            
-                                            Text("질문 추가")
-                                                .font(.pretendard(.bold, size: ._16))
-                                                .foregroundColor(Color.designSystem(.g1))
-                                                
-                                        })
-                                        .frame(maxWidth: .infinity)
-                                        .frame(height: 56)
-                                        .background(Color.designSystem(.g8))
-                                        .cornerRadius(16)
-                                        .padding(.top, 16)
-                                        
-                                    }
-                                    .background(
-                                        Color.designSystem(.g9)
-                                    )
-                                    .listRowInsets(EdgeInsets())
-                                    
+                VStack {
+                    titleTextField()
+                    
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            ForEach($viewModel.quiz.questions, id: \.id) { item in
+                                QuestionView(model: item, onRemove: { index in
+                                    removedIndex = (popupPresented: true, index: index)
+                                }, onExpand: { index in
+                                    viewModel.toggleExpand(index)
+                                    proxy.scrollTo(item.id, anchor: .center)
                                 })
+                                .padding(.bottom, 12)
+                                .id(item.id)
                             }
-                            .listStyle(.plain)
-                            .padding(EdgeInsets(top: 30, leading: 20, bottom: 0, trailing: 20))
+                            .onMove(perform: moveListItem)
+                            
+                            addAnswerView()
+                                .padding(.horizontal, 20)
+                            
                         }
-                        
-                        Spacer()
-
-                        WQButton(
-                          style: .single(
-                              .init(title: "시험지 완성하기",
-                                  action: {
-                                      interactor?.requestMakeQuiz(request: .init(quiz: viewModel.quiz))
-                                  }))
-                        )
-                        .frame(height: 52)
+                        .padding(.top, 30)
                     }
+
+                    Spacer()
+
+                    WQButton(
+                      style: .single(
+                          .init(title: "시험지 완성하기",
+                              action: {
+                                  interactor?.requestMakeQuiz(request: .init(quiz: viewModel.quiz))
+                              }))
+                    )
+                    .frame(height: 52)
                 }
                 .frame(maxWidth: .infinity)
                 .ignoresSafeArea(.keyboard, edges: .bottom)
@@ -134,6 +101,43 @@ public struct MakeQuizView: View {
                 }
             }
         }
+    }
+    
+    private func titleTextField() -> some View {
+        TextField("", text: $viewModel.quiz.title, prompt: Text("제목없는 시험지").foregroundColor(Color.designSystem(.g4)))
+            .frame(height: 34)
+            .onReceive(Just(viewModel.quiz.title)) { _ in
+                viewModel.limitQuizName()
+            }
+            .font(.pretendard(.medium, size: ._24))
+            .foregroundColor(Color.designSystem(.g4))
+            .padding(EdgeInsets(top: 24, leading: 20, bottom: 0, trailing: 20))
+    }
+    
+    private func addAnswerView() -> some View {
+        Button(action: {
+            if self.viewModel.quiz.questions.count >= 10 { return }
+            self.viewModel.quiz.questions.append(MakeQuestionModel())
+        }) {
+            HStack(alignment: .center, spacing: 7, content: {
+                Image(Icon.Add.circle)
+                    .frame(width: 16.5, height: 16.5)
+                
+                Text("질문 추가")
+                    .font(.pretendard(.bold, size: ._16))
+                    .foregroundColor(Color.designSystem(.g1))
+                    
+            })
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .background(Color.designSystem(.g8))
+            .cornerRadius(16)
+            .padding(.bottom, 20)
+            
+        }
+        .background(
+            Color.designSystem(.g9)
+        )
     }
     
     private func moveListItem(from source: IndexSet, to destination: Int) {

--- a/Projects/WeQuiz/Sources/Quiz/Question/QuestionView.swift
+++ b/Projects/WeQuiz/Sources/Quiz/Question/QuestionView.swift
@@ -13,7 +13,7 @@ import DesignSystemKit
 public struct QuestionView: View {
     
     @Binding private var model: MakeQuestionModel
-    @State private var expandedHeight: CGFloat = 250
+    @State private var expandedHeight: CGFloat = 326
     
     private var onRemove: ((UUID) -> ())?
     private var onExpand: ((UUID) -> ())?
@@ -26,47 +26,48 @@ public struct QuestionView: View {
     
     public var body: some View {
         ZStack(alignment: .topTrailing) {
-            VStack {
+            VStack(spacing: 0) {
                 questionTextField()
-                VStack {
-                    answerInputs()
-                    AddAnswerButtonView(answerNumber: $model.answers.count)
-                        .frame(height: 72)
-                        .onTapGesture {
-                            addAnswer()
-                        }
-                    
-                    MultipleSelectionView(isSelected: $model.duplicatedOption)
-                        .onChange(of: model.duplicatedOption) { newValue in
-                            if newValue == false {
-                                deselectAllList()
+                
+                if model.isExpand {
+                    VStack {
+                        answerInputs()
+                        AddAnswerButtonView(answerNumber: $model.answers.count)
+                            .frame(height: 56)
+                            .onTapGesture {
+                                addAnswer()
                             }
-                        }
-                    
+
+                        MultipleSelectionView(isSelected: $model.duplicatedOption)
+                            .onChange(of: model.duplicatedOption) { newValue in
+                                if newValue == false {
+                                    deselectAllList()
+                                }
+                            }
+
+                    }
+                    .padding(.horizontal, 20)
                 }
-                .hidden(!model.isExpand)
-                .modifier(AnimatingCellHeight(height: model.isExpand ? expandedHeight : 0))
-                .padding(.horizontal, 20)
                 
                 Spacer()
                 
             }
+            .frame(height: model.isExpand ? expandedHeight : 66)
             .background(
                 Color.designSystem(.g8)
             )
             .cornerRadius(16)
+            .padding(.horizontal, 20)
+            .padding(.top, 4)
             
-            if model.isExpand == true {
-                Image(Icon.Close.fillWhite)
-                    .onTapGesture {
-                        onRemove?(model.id)
-                    }
-            }
+            Image(Icon.Close.fillWhite)
+                .onTapGesture {
+                    onRemove?(model.id)
+                }
+                .padding(.trailing, 14)
+                .hidden(!model.isExpand)
         }
-        .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets())
-        .listRowBackground(Color.clear)
-        .padding([.top, .bottom], 8)
+        
     }
     
     private func questionTextField() -> some View {
@@ -75,10 +76,10 @@ public struct QuestionView: View {
                 .foregroundColor(.designSystem(.g4))
             )
             .font(.pretendard(.medium, size: ._18))
-            .frame(minHeight: 26)
+            .frame(height: 66)
             .frame(maxWidth: .infinity, alignment: .leading)
             .foregroundColor(.designSystem(.g4))
-            .padding([.top, .horizontal], 20)
+            .padding(.horizontal, 20)
             .onTapGesture {
                 withAnimation(.linear(duration: 0.3)) {
                     model.isExpand.toggle()
@@ -99,13 +100,14 @@ public struct QuestionView: View {
                     model.answers[index].isCorrect = true
                 }
             })
+            .padding(.bottom, 10)
         }
     }
     
     private func addAnswer() {
         if self.model.answers.count >= 5 { return }
+        self.expandedHeight += 72
         self.model.answers.append(MakeAnswerModel.init())
-        self.expandedHeight += 65
     }
     
     private func deselectAllList() {


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #89 


# 변경사항

## 작업 내용
- 문제 펼쳤다 접으면 합쳐지는 이슈 수정
- 문제 닫기 버튼 위치 조정
- 답변 입력 텍스트 뷰 간격 수정

## 스크린샷
https://github.com/mash-up-kr/weQuiz-iOS/assets/37571027/5b6e0f42-4d11-4a92-b74a-b211f162e4b3

