### PR TITLE
[DA] 문제풀기 플로우 점검 및 디자인 수정

### DIFF
--- a/Projects/WeQuiz/Sources/Quiz/QuizResult/QuizResultView.swift
+++ b/Projects/WeQuiz/Sources/Quiz/QuizResult/QuizResultView.swift
@@ -31,7 +31,7 @@ public struct QuizResultView: View {
     
     public var body: some View {
         ZStack(alignment: .topTrailing) {
-            ScrollView(.vertical) {
+            ScrollView(.vertical, showsIndicators: false) {
                 VStack {
                     VStack(alignment: .center, spacing: 20) {
                         if let result = model.result {
@@ -40,27 +40,42 @@ public struct QuizResultView: View {
                         }
                     }
 
-                    Image(model.result?.resultImage ?? "quizResult_5")
-                        .resizable()
-                        .aspectRatio(1.0, contentMode: .fit)
+                    HStack {
+                        Spacer()
+                        if let ranking = model.result?.ranking, ranking.count >= 3 {
+                            Image(model.result?.resultImage ?? "quizResult_5")
+                        } else {
+                            Image(model.result?.resultImage ?? "quizResult_5")
+                                .resizable()
+                                .aspectRatio(1.0, contentMode: .fit)
+                        }
+                        Spacer()
+                    }
 
                     rankingView()
                         .hidden(model.result?.ranking == nil)
+                    Spacer()
+                        .frame(height: 72)
                 }
             }
-            .padding(.top, 58)
-            .padding(.bottom, 128)
+            .padding(.top, 56)
+            .padding(.bottom, 72)
             .disabled(model.result?.ranking == nil)
 
-            VStack {
+            VStack(spacing: .zero) {
                 topBar()
 
                 Spacer()
 
-                VStack(spacing: 22) {
-
+                VStack(spacing: .zero) {
+                    LinearGradient(
+                        colors: [.clear, .designSystem(.g9)],
+                        startPoint: .init(x: 0.5, y: 0),
+                        endPoint: .init(x: 0.5, y: 1)
+                    )
+                    .frame(height: 72)
                     WQButton(style: .double(WQButton.Style.DobuleButtonStyleModel(
-                        titles: (leftTitle: "다시 풀기", rightTitle: "결과 공유하기"),
+                        titles: (leftTitle: "다시 풀기", rightTitle: "문제 공유하기"),
                         leftAction: {
                             solveQuizNavigator.popToroot()
                         },
@@ -69,6 +84,7 @@ public struct QuizResultView: View {
                             resultLink(id: quizId)
                         }
                     )))
+                    .background(Color.black)
                     .background(
                         ActivityView(
                             isPresented: $isSharePresented,
@@ -78,7 +94,7 @@ public struct QuizResultView: View {
                 }
             }
         }
-        .background(Color.designSystem(.g9))
+        .edgesIgnoringSafeArea(.bottom)
         .task {
             if let quizId = model.quizId {
                 interactor?.requestRanking(request: .init(quizId: quizId))
@@ -123,13 +139,13 @@ extension QuizResultView {
     }
 
     private func rankingView() -> some View {
-        VStack {
-            Rectangle()
-                .fill(Color.designSystem(.g7))
-                .frame(height: 8)
-
-            if let ranking = model.result?.ranking {
-                ForEach(ranking, id: \.rank) { user in
+        VStack(spacing: .zero) {
+            if let ranking = model.result?.ranking, ranking.count >= 3 {
+                Rectangle()
+                    .fill(Color.designSystem(.g9))
+                    .frame(height: 8)
+                
+                ForEach(.constant(ranking), id: \.rank) { user in
                     QuizResultRankView(user)
                 }
                 .padding(.horizontal, 20)
@@ -151,11 +167,11 @@ extension QuizResultView {
                 }
         }
         .frame(height: 56)
-        .background(Color.designSystem(.g9))
+        .background(Color.clear)
     }
     
     private func resultLink(id: Int) {
-        DynamicLinks.makeDynamicLink(type: .result(id: id)) {
+        DynamicLinks.makeDynamicLink(type: .solve(id: id)) {
             guard let url = $0 else { return }
             activityItem = [url]
             isSharePresented = true

--- a/Projects/WeQuiz/Sources/Quiz/QuizResult/View+/QuizResultRankView.swift
+++ b/Projects/WeQuiz/Sources/Quiz/QuizResult/View+/QuizResultRankView.swift
@@ -11,11 +11,10 @@ import SwiftUI
 import DesignSystemKit
 
 struct QuizResultRankView: View {
+    @Binding private var model: RankUserModel
     
-    private let model: RankUserModel
-    
-    public init(_ model: RankUserModel) {
-        self.model = model
+    public init(_ model: Binding<RankUserModel>) {
+        self._model = model
     }
     
     var body: some View {
@@ -60,11 +59,5 @@ struct QuizResultRankView: View {
         default:
             return Image(Icon.Medal.bronze)
         }
-    }
-}
-
-struct QuizResultRankCell_Previews: PreviewProvider {
-    static var previews: some View {
-        QuizResultRankView(.init(id: 1234, name: "감자", rank: 1, score: 100))
     }
 }

--- a/Projects/WeQuiz/Sources/Quiz/SolveQuiz/SolveQuizDataStore.swift
+++ b/Projects/WeQuiz/Sources/Quiz/SolveQuiz/SolveQuizDataStore.swift
@@ -15,6 +15,8 @@ final class SolveQuizDataStore: ObservableObject {
     @Published var routeToResultView = false
     @Published var quizResult: QuizResultModel?
     @Published var routeToNameInputView = false
+    
+    var selectedCount: Int = .zero
 
     public init(_ quiz: SolveQuizModel) {
         self.quiz = quiz

--- a/Projects/WeQuiz/Sources/Quiz/SolveQuiz/View+/SolveQuizAnswerView.swift
+++ b/Projects/WeQuiz/Sources/Quiz/SolveQuiz/View+/SolveQuizAnswerView.swift
@@ -54,19 +54,19 @@ public struct SolveQuizAnswerView: View {
         self.currentAnswerIndex = currentAnswerIndex
     }
     
-    public var body: some View {
-        Text(model.answer)
-            .font(.pretendard(.bold, size: ._18))
-            .foregroundColor(model.isSelected ? Color.designSystem(.g9) : .designSystem(.g2))
-            .frame(maxWidth: .infinity, alignment: .center)
-            .frame(height: 58)
-            .background(
-                backgroundColor()
-            )
-            .cornerRadius(16)
-            .onTapGesture {
-                model.isSelected.toggle()
-            }
+    public var body: some View {    
+        ZStack {
+            Text(model.answer)
+                .lineLimit(2)
+                .font(.pretendard(.bold, size: ._18))
+                .foregroundColor(model.isSelected ? Color.designSystem(.g9) : .designSystem(.g2))
+                .padding(.all, 16)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .background(
+            backgroundColor()
+        )
+        .cornerRadius(16)
     }
 }
 

--- a/Projects/WeQuiz/Sources/Quiz/SolveQuiz/View+/SolveQuizAnswerView.swift
+++ b/Projects/WeQuiz/Sources/Quiz/SolveQuiz/View+/SolveQuizAnswerView.swift
@@ -64,6 +64,9 @@ public struct SolveQuizAnswerView: View {
                 backgroundColor()
             )
             .cornerRadius(16)
+            .onTapGesture {
+                model.isSelected.toggle()
+            }
     }
 }
 


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve  #117 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 퀴즈 정답 선택 시 이동 할때 onChange가 정답 선택 시 한번 더 호출되므로 조건문 추가
* 문제풀기 결과 화면의 디자인 수정
  * 랭킹이 2명 이하일 때는 이미지 크게
  * 랭킹이 세명 이상일 때는 이미지 작게 + 랭킹 노출

### 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->
랭킹X|랭킹O
---|---
![랭킹X](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/2a48f363-bcee-4837-8a6d-38c0b510c93c)|![랭킹0](https://github.com/mash-up-kr/weQuiz-iOS/assets/39300449/d5e2f748-3d99-460f-9065-71f0a99a6d01)

